### PR TITLE
Build against wasm substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,21 @@ name = "elgamal_wasm"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 encoding = "0.2.33"
-num = { version = "0.3.1", features = ["rand"] }
+num-bigint = { version = "0.4.3", default-features = false, features = ["rand"] }
+num-integer = {version = "0.1.44", default-features = false}
+num-traits = {version = "0.2.14", default-features = false}
 mt19937 = "2.0.1"
 rand = { version = "0.6", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false }
-const_num_bigint = "0.2.1"
+
+[features]
+default = ["std"]
+std = [
+    "num-bigint/std",
+    "num-integer/std",
+    "num-traits/std",
+    "rand/std",
+    "rand_core/std"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ encoding = "0.2.33"
 num = { version = "0.3.1", features = ["rand"] }
 mt19937 = "2.0.1"
 rand = { version = "0.6", default-features = false, optional = true }
-rand_core = { version = "0.6", features = ["std"] }
+rand_core = { version = "0.6", default-features = false }
 const_num_bigint = "0.2.1"

--- a/src/elgamal.rs
+++ b/src/elgamal.rs
@@ -2,10 +2,10 @@
 //! this is a utils for elgamal security algorithm
 //! use for generating public_key
 use crate::utils;
-use const_num_bigint::{BigInt, BigUint};
 use encoding::all::UTF_16LE;
 use encoding::{EncoderTrap, Encoding};
 use mt19937;
+use num_bigint::{BigInt, BigUint};
 use std::fmt;
 
 /// trait for printing some struct
@@ -100,7 +100,7 @@ pub fn generate_pub_key(
 /// # Example
 /// ```rust
 /// use elgamal_wasm as elgamal;
-/// use num::bigint::BigUint;
+/// use num_bigint::BigUint;
 /// let big_num = BigUint::from(2929u32);
 /// let tuple = elgamal::generate_pub_key(&big_num.to_u32_digits(),32,32).unwrap();
 /// let pubkey = tuple.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 //! let pubkey = tuple.0;
 //! let mt19937 = tuple.1;
 //! ```
-
 mod elgamal;
 pub use crate::elgamal::*;
 pub mod utils;
@@ -21,7 +20,7 @@ mod tests {
 
     //TODO: convert String to Vec<u32>
     #[test]
-    fn test_string_to_vecu32() {
+    fn test_string_to_vec_u32() {
         let big_num =
             "833050814021254693158343911234888353695402778102174580258852673738983005".as_bytes();
         println!("~~~~~~~~~~~~~~~~{:?}", big_num);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,21 +5,10 @@
 //! generate h: a random from seed
 use mt19937;
 use mt19937::MT19937;
-
-use const_num_bigint::*;
-use num::traits::{One, Zero};
-use num::{Integer, ToPrimitive};
-
-/// const for 0,1 ..
-const BIGINT_0: &'static BigInt = bigint!("0");
-const BIGINT_1: &'static BigInt = bigint!("1");
-const BIGINT_2: &'static BigInt = bigint!("2");
-const BIGINT_R1: &'static BigInt = bigint!("-1");
-const BIGINT_3: &'static BigInt = bigint!("3");
-const BIGINT_4: &'static BigInt = bigint!("4");
-const BIGINT_5: &'static BigInt = bigint!("5");
-const BIGINT_7: &'static BigInt = bigint!("7");
-const BIGINT_8: &'static BigInt = bigint!("8");
+use num_bigint::{BigInt, BigUint, Sign};
+use num_integer::Integer;
+use num_traits::cast::ToPrimitive;
+use num_traits::identities::Zero;
 
 /** These real versions are due to Kaisuki, 2021/01/07 added */
 /// random generator for bigint
@@ -41,9 +30,6 @@ pub fn gen_bigint_range<R: rand_core::RngCore>(
 fn getrandbits<R: rand_core::RngCore>(rng: &mut R, k: usize) -> BigInt {
     if k == 0 {
         return BigInt::from_slice(Sign::NoSign, &[0]);
-        // return Err(
-        //     vm.new_value_error("number of bits must be greater than zero".to_owned())
-        // );
     }
 
     // let mut rng = self.rng.lock();
@@ -62,7 +48,7 @@ fn getrandbits<R: rand_core::RngCore>(rng: &mut R, k: usize) -> BigInt {
     }
 
     let words = (k - 1) / 32 + 1;
-    let wordarray = (0..words)
+    let word_array = (0..words)
         .map(|_| {
             let word = gen_u32(k);
             k = k.wrapping_sub(32);
@@ -70,7 +56,7 @@ fn getrandbits<R: rand_core::RngCore>(rng: &mut R, k: usize) -> BigInt {
         })
         .collect::<Vec<_>>();
 
-    let uint = BigUint::new(wordarray);
+    let uint = BigUint::new(word_array);
     // very unlikely but might as well check
     let sign = if uint.is_zero() {
         Sign::NoSign
@@ -83,25 +69,28 @@ fn getrandbits<R: rand_core::RngCore>(rng: &mut R, k: usize) -> BigInt {
 ///Find a prime number p for elgamal public key.
 #[allow(unused)]
 pub fn random_prime_bigint(bit_length: u32, i_confidence: u32, r: &mut mt19937::MT19937) -> BigInt {
+    let big_int_0 = BigInt::from(0);
+    let big_int_1 = BigInt::from(1);
+    let big_int_2 = BigInt::from(2);
     //keep testing until one is found
     loop {
         // generate potential prime randomly
         let mut p = gen_prime(&bit_length, r);
         // make sure it is odd
-        while p.mod_floor(&BIGINT_2) == *BIGINT_0 {
+        while p.mod_floor(&big_int_2) == big_int_0.clone() {
             p = gen_prime(&bit_length, r);
         }
         // keep doing this if the solovay-strassen test fails
         while solovay_strassen(&p, i_confidence, r) != true {
             p = gen_prime(&bit_length, r);
-            while p.mod_floor(&BIGINT_2) == *BIGINT_0 {
+            while p.mod_floor(&big_int_2) == big_int_0 {
                 p = gen_prime(&bit_length, r);
             }
         }
         // if p is prime compute p = 2*p + 1
         // this step is critical to protect the encryption from Pohlig–Hellman algorithm
         // if p is prime, we have succeeded; else, start over
-        p = p * BIGINT_2 + BIGINT_1;
+        p = p * &big_int_2 + &big_int_1;
         if solovay_strassen(&p, i_confidence, r) == true {
             return p;
         }
@@ -125,25 +114,27 @@ fn gen_prime(bit_length: &u32, r: &mut mt19937::MT19937) -> BigInt {
 /// This function was implemented from the algorithm described here:
 /// http://modular.math.washington.edu/edu/2007/spring/ent/ent-html/node31.html
 pub fn find_primitive_root_bigint(p: &BigInt, r: &mut mt19937::MT19937) -> BigInt {
+    let big_int_1 = BigInt::from(1);
+    let big_int_2 = BigInt::from(2);
     //if p == 2: return 1
-    if *p == *BIGINT_2 {
-        return BIGINT_1.clone();
+    if p == &big_int_2 {
+        return big_int_1;
     }
 
     // p2 = (p-1)/2
     // p3 = (p-1)/p2
-    let p2: BigInt = (p - BIGINT_1) / BIGINT_2;
-    let p3: BigInt = (p - BIGINT_1) / &p2;
+    let p2: BigInt = (p - &big_int_1) / &big_int_2;
+    let p3: BigInt = (p - &big_int_1) / &p2;
     let mut g;
     //test random g's until one is found that is a primitive root mod p
     loop {
-        let range_num_low: BigInt = BIGINT_2.clone();
-        let range_num_high: BigInt = p - BIGINT_1;
+        let range_num_low: BigInt = big_int_2.clone();
+        let range_num_high: BigInt = p - &big_int_1;
         g = gen_bigint_range(r, &range_num_low, &range_num_high);
         // g is a primitive root if for all prime factors of p-1, p[i]
         // g^((p-1)/p[i]) (mod p) is not congruent to 1
-        if g.modpow(&p2, &p) != *BIGINT_1 {
-            if g.modpow(&p3, &p) != *BIGINT_1 {
+        if g.modpow(&p2, &p) != big_int_1.clone() {
+            if g.modpow(&p3, &p) != big_int_1 {
                 return g;
             }
         }
@@ -152,11 +143,10 @@ pub fn find_primitive_root_bigint(p: &BigInt, r: &mut mt19937::MT19937) -> BigIn
 
 /// generate h for public_key
 pub fn find_h_bigint(p: &BigInt, r: &mut mt19937::MT19937) -> BigInt {
-    let one: BigInt = One::one();
-    let range_num_low: BigInt = One::one();
+    let one: BigInt = BigInt::from(1);
+    let range_num_low: BigInt = one.clone();
     let range_num_high: BigInt = p - &one;
-    let h = gen_bigint_range(r, &range_num_low, &range_num_high);
-    h
+    gen_bigint_range(r, &range_num_low, &range_num_high)
 }
 
 /// Solovay-strassen primality test.
@@ -166,77 +156,96 @@ pub fn find_h_bigint(p: &BigInt, r: &mut mt19937::MT19937) -> BigInt {
 /// if pass the test
 /// ensure confidence of t
 pub fn solovay_strassen(num: &BigInt, i_confidence: u32, r: &mut MT19937) -> bool {
+    let big_int_1 = BigInt::from(1);
+    let big_int_2 = BigInt::from(2);
     for _idx in 0..i_confidence {
         // let one: BigInt = One::one();
-        let high: BigInt = num - BIGINT_1;
+        let high: BigInt = num - &big_int_1;
         //choose random a between 1 and n-2
-        let a: BigInt = gen_bigint_range(r, &BIGINT_1, &high);
+        let a: BigInt = gen_bigint_range(r, &big_int_1, &high);
 
         // let two: BigInt = &one +&one;
         // if a is not relatively prime to n, n is composite
-        if a.gcd(num) > *BIGINT_1 {
+        if a.gcd(num) > big_int_1.clone() {
             return false;
         }
         //declares n prime if jacobi(a, n) is congruent to a^((n-1)/2) mod n
         let jacobi_result: BigInt = jacobi(&a, num).mod_floor(num);
-        let mi: BigInt = (num - BIGINT_1) / BIGINT_2;
-        let pow_reulst: BigInt = a.modpow(&mi, num);
-        if jacobi_result != pow_reulst {
+        let mi: BigInt = (num - &big_int_1) / &big_int_2;
+        let pow_res: BigInt = a.modpow(&mi, num);
+        if jacobi_result != pow_res {
             return false;
         }
     }
     //if there have been t iterations without failure, num is believed to be prime
-    return true;
+    true
 }
 
 /// Computes the jacobi symbol of a, n.
 pub fn jacobi(a: &BigInt, n: &BigInt) -> BigInt {
+    let big_int_r1 = BigInt::from(-1);
+    let big_int_0 = BigInt::from(0);
+    let big_int_1 = BigInt::from(1);
+    let big_int_2 = BigInt::from(2);
+    let big_int_3 = BigInt::from(3);
+    let big_int_5 = BigInt::from(5);
+    let big_int_7 = BigInt::from(7);
+    let big_int_8 = BigInt::from(8);
     if a.to_i64().is_none() {
         jacobi_match_else(a, n)
     } else {
         let a_f64_value = a.to_i64().unwrap();
-        return match a_f64_value {
+        match a_f64_value {
             0 => {
-                if n == BIGINT_1 {
-                    BIGINT_1.clone()
+                if n == &big_int_1 {
+                    big_int_1
                 } else {
-                    BIGINT_0.clone()
+                    big_int_0
                 }
             }
             -1 => {
-                if n.mod_floor(&BIGINT_2) == *BIGINT_0 {
-                    BIGINT_1.clone()
+                if n.mod_floor(&big_int_2) == big_int_0 {
+                    big_int_1
                 } else {
-                    BIGINT_R1.clone()
+                    big_int_r1
                 }
             }
-            1 => BIGINT_1.clone(),
+            1 => big_int_1,
             2 => {
-                if (n.mod_floor(&BIGINT_8) == *BIGINT_1) || (n.mod_floor(&BIGINT_8) == *BIGINT_7) {
-                    BIGINT_1.clone()
-                } else if (n.mod_floor(&BIGINT_8) == *BIGINT_3)
-                    || (n.mod_floor(&BIGINT_8) == *BIGINT_5)
+                if (n.mod_floor(&big_int_8) == big_int_1.clone())
+                    || (n.mod_floor(&big_int_8) == big_int_7)
                 {
-                    BIGINT_R1.clone()
+                    big_int_1
+                } else if (n.mod_floor(&big_int_8) == big_int_3)
+                    || (n.mod_floor(&big_int_8) == big_int_5)
+                {
+                    big_int_r1
                 } else {
-                    BIGINT_0.clone()
+                    big_int_0
                 }
             }
             _ => jacobi_match_else(a, n),
-        };
+        }
     }
 }
 
 /// Computes the jacobi symbol of a, n.If don't match any pattern or a cannot convert to i64
 fn jacobi_match_else(a: &BigInt, n: &BigInt) -> BigInt {
+    let big_int_0 = BigInt::from(0);
+    let big_int_2 = BigInt::from(2);
+    let big_int_r1 = BigInt::from(-1);
+    let big_int_3 = BigInt::from(3);
+    let big_int_4 = BigInt::from(4);
     if a > n {
         let tmp_a = a.mod_floor(n);
         jacobi(&tmp_a, n)
-    } else if a.mod_floor(&BIGINT_2) == *BIGINT_0 {
-        let tmp_a2 = a / BIGINT_2;
-        jacobi(&BIGINT_2, n) * jacobi(&tmp_a2, n)
-    } else if (a.mod_floor(&BIGINT_4) == *BIGINT_3) && (n.mod_floor(&BIGINT_4) == *BIGINT_3) {
-        BIGINT_R1 * jacobi(n, a)
+    } else if a.mod_floor(&big_int_2) == big_int_0 {
+        let tmp_a2 = a / &big_int_2;
+        jacobi(&big_int_2, n) * jacobi(&tmp_a2, n)
+    } else if (a.mod_floor(&big_int_4) == big_int_3.clone())
+        && (n.mod_floor(&big_int_4) == big_int_3)
+    {
+        big_int_r1 * jacobi(n, a)
     } else {
         jacobi(n, a)
     }
@@ -244,10 +253,10 @@ fn jacobi_match_else(a: &BigInt, n: &BigInt) -> BigInt {
 
 /// pow operation for bigint
 pub fn pow_bigint(base: &BigInt, exponent: &BigInt) -> BigInt {
-    let zero: BigInt = Zero::zero();
-    let one: BigInt = One::one();
+    let zero = BigInt::from(0);
+    let one = BigInt::from(1);
 
-    let mut result: BigInt = One::one();
+    let mut result: BigInt = one.clone();
     let mut e: BigInt = exponent.clone();
     let mut b: BigInt = base.clone();
 


### PR DESCRIPTION
Fix no-std problem in building substrate WASM runtime. Remove conflict dependencies.
Added a feature to turn-off std dependency in "num" modules.
If build with WASM, add "default-features = false" to Cargo.toml.
